### PR TITLE
bug: Svelte warnings in webpack build

### DIFF
--- a/src/lib/MarkerAdmin/MarkerAdmin.svelte
+++ b/src/lib/MarkerAdmin/MarkerAdmin.svelte
@@ -24,7 +24,7 @@
 
   let hasLoaded = $state(false);
   let markers = $state<Marker[]>([]);
-  let mode = $state(Object.keys(prefixes)?.[0]);
+  let mode = $state(untrack(() => Object.keys(prefixes)?.[0]));
 
   /** which button should show the success indicator */
   let successIndicator = $state("");
@@ -33,7 +33,9 @@
     window.location.pathname
       .match(/\/news-projects\/[^/]+\/(\d+\.\d+\.\d+)/)
       ?.slice(1) || [];
-  const localStorageKey = `ABC_NEWS_BUILDER_${projectName.toUpperCase().replace(/-/g, "_")}`;
+  const localStorageKey = $derived(
+    `ABC_NEWS_BUILDER_${projectName.toUpperCase().replace(/-/g, "_")}`,
+  );
 
   /** Load & sanitise markers from localStorage on initial load */
   $effect(() => {
@@ -76,7 +78,7 @@
     }
 
     interval = setInterval(() => {
-      const goodMarkers = (marker) =>
+      const goodMarkers = (marker: Marker) =>
         !marker.deleted || marker.deleted > Date.now() - 5000;
       if (!_markers.every(goodMarkers)) {
         markers = _markers.filter(goodMarkers);

--- a/src/lib/Typeahead/Typeahead.svelte
+++ b/src/lib/Typeahead/Typeahead.svelte
@@ -17,7 +17,7 @@
   } = $props();
 
   const uniqueId = "list" + (Math.random() * 10e15).toString(16);
-  let selectedValues = $state<string[]>(value);
+  let selectedValues = $state<string[]>(untrack(() => value));
   let isFocused = $state(false);
   let inputElement = $state<HTMLInputElement>();
   let inputValue = $state("");

--- a/src/lib/UpdateChecker/UpdateChecker.svelte
+++ b/src/lib/UpdateChecker/UpdateChecker.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import Modal from "$lib/Modal/Modal.svelte";
-  import { onMount } from "svelte";
+  import { onMount, untrack } from "svelte";
 
   type NewVersion = {
     newVersion: string;
@@ -12,9 +12,10 @@
     buttonText = "Open new builder",
   }: { overrideNewVersion?: NewVersion; buttonText?: string } = $props();
 
-  let newVersion = $state<NewVersion | undefined>(overrideNewVersion);
-  // svelte-ignore state_referenced_locally
-  let isOpen = $state(!!newVersion);
+  let newVersion = $state<NewVersion | undefined>(
+    untrack(() => overrideNewVersion),
+  );
+  let isOpen = $state(untrack(() => !!newVersion));
 
   /**
    * Check for a new version of the given project


### PR DESCRIPTION
This fixes the following lint error in various places:

> state_referenced_locally: This reference only captures the initial value of `projectName`. Did you mean to reference it inside a closure instead?

These weren't actual bugs, but kept popping up in the consuming webpack builds after a recent Svelte upgrade and it's annoying.