### PR TITLE
bug: remove conflicting styles from frame, let defaults shine through

### DIFF
--- a/src/lib/BuilderFrame/BuilderFrame.svelte
+++ b/src/lib/BuilderFrame/BuilderFrame.svelte
@@ -100,8 +100,6 @@
     min-width: 50%;
     position: relative;
     overflow: hidden;
-    background: var(--background-alt);
-    color: black;
 
     > * {
       margin: 5px;

--- a/src/lib/BuilderStyleRoot/BuilderStyleRoot.svelte
+++ b/src/lib/BuilderStyleRoot/BuilderStyleRoot.svelte
@@ -38,7 +38,7 @@
       .builder-style-root {
         --text: #ccc;
         --text-light: #888;
-        --background: #1a1a1a;
+        --background: #121212;
         --background-alt: #2c2c2f;
         --border: rgba(122, 123, 135, 0.5);
       }


### PR DESCRIPTION
problem: in dark mode the frame gets a dark background with dark text. We either shouldn't set anything here and let the viz handle its own dark/light mode, or should explicitly set both a foreground and background colour. I've gone with the former.

Causes issues like the following:

<img width="807" height="604" alt="image" src="https://github.com/user-attachments/assets/9daa961c-3414-4285-b727-0446932fa373" />
