### PR TITLE
feat: split BuilderViewport out from BuilderFrame so we can opt out of the viewport

### DIFF
--- a/src/lib/BuilderFrame/BuilderFrame.svelte
+++ b/src/lib/BuilderFrame/BuilderFrame.svelte
@@ -1,81 +1,25 @@
 <script lang="ts">
-  let { Viz, Sidebar } = $props();
+  import BuilderViewport from "../BuilderViewport/BuilderViewport.svelte";
 
-  let vizAreaWidth = $state();
-  let vizAreaHeight = $state();
+  interface Props {
+    /** Svelte snippet to render the visualization content. */
+    Viz?: import("svelte").Snippet;
+    /** Svelte snippet to render the sidebar content. */
+    Sidebar?: import("svelte").Snippet;
+    /** Whether to enable the viewport resizing and controls. Defaults to true. */
+    enableViewport?: boolean;
+  }
 
-  let vizDimensions: [number, number] = $state([Infinity, Infinity]);
-  let presetValue: [number, number] | "custom" | "auto" = $state("auto");
-
-  $effect(() => {
-    if (Array.isArray(presetValue)) {
-      vizDimensions = [presetValue[0], presetValue[1]];
-    }
-  });
-
-  $effect(() => {
-    const match = commonViewports
-      .values()
-      .find((d) => d[0] === vizDimensions[0] && d[1] === vizDimensions[1]);
-
-    if (!match) {
-      presetValue =
-        vizAreaWidth === vizDimensions[0] && vizAreaHeight === vizDimensions[1]
-          ? "auto"
-          : "custom";
-    }
-  });
-
-  const commonViewports = new Map<string, [number, number]>([
-    ["Desktop (large)", [1920, 1080]],
-    ["Desktop (small)", [1280, 720]],
-    ["iPad Pro", [1024, 1366]],
-    ["Surface Pro 7", [912, 1368]],
-    ["Gallaxy Note 20", [412, 915]],
-    ["iPhone 14 Pro Max", [430, 932]],
-    ["iPhone SE", [375, 667]],
-  ]);
+  let { Viz, Sidebar, enableViewport = true }: Props = $props();
 </script>
 
 <div class="builder-frame">
   <div class="builder-frame__viz">
-    <div class="tools">
-      <select name="resize-options" bind:value={presetValue}>
-        <option value={"auto"} selected>Auto</option>
-        <option value={"custom"}>Custom</option>
-        {#each commonViewports.entries() as [name, dimensions]}
-          <option value={dimensions}>{name}</option>
-        {/each}
-      </select>
-      <input
-        disabled={presetValue === "auto"}
-        id="viz-width"
-        type="number"
-        bind:value={vizDimensions[0]}
-      />
-      x
-      <input
-        disabled={presetValue === "auto"}
-        id="viz-height"
-        type="number"
-        bind:value={vizDimensions[1]}
-      />
-    </div>
-    <div
-      class="content-area"
-      bind:offsetWidth={vizAreaWidth}
-      bind:offsetHeight={vizAreaHeight}
-    >
-      <div
-        class="resize-frame"
-        bind:offsetWidth={vizDimensions[0]}
-        bind:offsetHeight={vizDimensions[1]}
-        style:width={presetValue === "auto" ? "100%" : `${vizDimensions[0]}px`}
-        style:height={presetValue === "auto" ? "100%" : `${vizDimensions[1]}px`}
-      >
-        {@render Viz?.()}
-      </div>
-    </div>
+    {#if enableViewport}
+      <BuilderViewport {Viz} />
+    {:else}
+      {@render Viz?.()}
+    {/if}
   </div>
 
   <div class="builder-frame__sidebar">{@render Sidebar?.()}</div>
@@ -93,47 +37,10 @@
     color: var(--text);
   }
   .builder-frame__viz {
-    display: grid;
-    grid-template-columns: 100%;
-    grid-template-rows: min-content 1fr;
     flex: 1;
     min-width: 50%;
     position: relative;
     overflow: hidden;
-
-    > * {
-      margin: 5px;
-    }
-
-    .tools {
-      width: 100%;
-      text-align: left;
-      font-size: 0.8em;
-      margin-bottom: 0;
-      select {
-        width: 8em;
-      }
-
-      input[type="number"] {
-        width: 5em;
-        &[disabled] {
-          opacity: 0.3;
-        }
-      }
-    }
-
-    .content-area {
-      overflow: auto;
-      display: block;
-
-      .resize-frame {
-        resize: both;
-        overflow: auto;
-        background-color: var(--background);
-        border: 1px solid hsl(from var(--border) h s l / 0.2);
-        box-shadow: hsl(from var(--border) h s l / 0.1) 0 0 5px;
-      }
-    }
   }
 
   .builder-frame__sidebar {
@@ -148,3 +55,4 @@
     }
   }
 </style>
+

--- a/src/lib/BuilderViewport/BuilderViewport.stories.svelte
+++ b/src/lib/BuilderViewport/BuilderViewport.stories.svelte
@@ -1,12 +1,11 @@
 <script module>
   import { defineMeta } from "@storybook/addon-svelte-csf";
-  import BuilderFrame from "./BuilderFrame.svelte";
+  import BuilderViewport from "./BuilderViewport.svelte";
   import BuilderStyleRoot from "$lib/BuilderStyleRoot/BuilderStyleRoot.svelte";
 
-  // More on how to set up stories at: https://storybook.js.org/docs/writing-stories
   const { Story } = defineMeta({
-    title: "Example/BuilderFrame",
-    component: BuilderFrame,
+    title: "Example/BuilderViewport",
+    component: BuilderViewport,
     tags: ["autodocs"],
     argTypes: {},
     args: {},
@@ -15,29 +14,15 @@
   });
 </script>
 
-{#snippet Sidebar()}
-  Sidebar
-{/snippet}
-
 {#snippet Viz()}
-  Viz
+  <div style="padding: 20px; background: #eee; color: #333; height: 100%; box-sizing: border-box;">
+    Visualization Content Area
+  </div>
 {/snippet}
 
-<!-- More on writing stories with args: https://storybook.js.org/docs/writing-stories/args -->
 <Story
   name="Primary"
   args={{
-    Sidebar,
     Viz,
   }}
 />
-
-<Story
-  name="Without Viewport"
-  args={{
-    Sidebar,
-    Viz,
-    enableViewport: false,
-  }}
-/>
-

--- a/src/lib/BuilderViewport/BuilderViewport.svelte
+++ b/src/lib/BuilderViewport/BuilderViewport.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  interface Props {
+    /** The visualization snippet to render. */
+    Viz?: import("svelte").Snippet;
+  }
+
+  let { Viz }: Props = $props();
+
+  let vizAreaWidth = $state();
+  let vizAreaHeight = $state();
+
+  let vizDimensions: [number, number] = $state([Infinity, Infinity]);
+  let presetValue: [number, number] | "custom" | "auto" = $state("auto");
+
+  $effect(() => {
+    if (Array.isArray(presetValue)) {
+      vizDimensions = [presetValue[0], presetValue[1]];
+    }
+  });
+
+  $effect(() => {
+    const match = Array.from(commonViewports.values()).find(
+      (d) => d[0] === vizDimensions[0] && d[1] === vizDimensions[1]
+    );
+
+    if (!match) {
+      presetValue =
+        vizAreaWidth === vizDimensions[0] && vizAreaHeight === vizDimensions[1]
+          ? "auto"
+          : "custom";
+    }
+  });
+
+  const commonViewports = new Map<string, [number, number]>([
+    ["Desktop (large)", [1920, 1080]],
+    ["Desktop (small)", [1280, 720]],
+    ["iPad Pro", [1024, 1366]],
+    ["Surface Pro 7", [912, 1368]],
+    ["Gallaxy Note 20", [412, 915]],
+    ["iPhone 14 Pro Max", [430, 932]],
+    ["iPhone SE", [375, 667]],
+  ]);
+</script>
+
+<div class="builder-viewport">
+  <div class="tools">
+    <select name="resize-options" bind:value={presetValue}>
+      <option value={"auto"} selected>Auto</option>
+      <option value={"custom"}>Custom</option>
+      {#each commonViewports.entries() as [name, dimensions]}
+        <option value={dimensions}>{name}</option>
+      {/each}
+    </select>
+    <input
+      disabled={presetValue === "auto"}
+      id="viz-width"
+      type="number"
+      bind:value={vizDimensions[0]}
+    />
+    x
+    <input
+      disabled={presetValue === "auto"}
+      id="viz-height"
+      type="number"
+      bind:value={vizDimensions[1]}
+    />
+  </div>
+  <div
+    class="content-area"
+    bind:offsetWidth={vizAreaWidth}
+    bind:offsetHeight={vizAreaHeight}
+  >
+    <div
+      class="resize-frame"
+      bind:offsetWidth={vizDimensions[0]}
+      bind:offsetHeight={vizDimensions[1]}
+      style:width={presetValue === "auto" ? "100%" : `${vizDimensions[0]}px`}
+      style:height={presetValue === "auto" ? "100%" : `${vizDimensions[1]}px`}
+    >
+      {@render Viz?.()}
+    </div>
+  </div>
+</div>
+
+<style>
+  .builder-viewport {
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: min-content 1fr;
+    height: 100%;
+    width: 100%;
+    position: relative;
+    overflow: hidden;
+
+    > * {
+      margin: 5px;
+    }
+
+    .tools {
+      width: 100%;
+      text-align: left;
+      font-size: 0.8em;
+      margin-bottom: 0;
+      select {
+        width: 8em;
+      }
+
+      input[type="number"] {
+        width: 5em;
+        &[disabled] {
+          opacity: 0.3;
+        }
+      }
+    }
+
+    .content-area {
+      overflow: auto;
+      display: block;
+
+      .resize-frame {
+        resize: both;
+        overflow: auto;
+        background-color: var(--background);
+        border: 1px solid hsl(from var(--border) h s l / 0.2);
+        box-shadow: hsl(from var(--border) h s l / 0.1) 0 0 5px;
+      }
+    }
+  }
+</style>

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -11,3 +11,4 @@ export { default as MarkerAdmin } from "./MarkerAdmin/MarkerAdmin.svelte";
 export { default as Loader } from "./Loader/Loader.svelte";
 export { default as ItemCollection } from "./ItemCollection/ItemCollection.svelte";
 export { default as FormActions } from "./ItemCollection/FormActions.svelte";
+export { default as BuilderViewport } from "./BuilderViewport/BuilderViewport.svelte";


### PR DESCRIPTION
Basically in the Zoomyteller we want to use the viewport as a sort of wysiwyg editor so the viewports really don't make sense.

I made it a separate component because hope to still use it in a preview mode in the zoomyteller builder.